### PR TITLE
Fix for skipping closed generic tasks

### DIFF
--- a/src/src/org/github/olloginov/ideataskbrowser/tasks/FetchNewIssuesFromRepoTask.java
+++ b/src/src/org/github/olloginov/ideataskbrowser/tasks/FetchNewIssuesFromRepoTask.java
@@ -134,7 +134,12 @@ public class FetchNewIssuesFromRepoTask extends Task.Backgroundable {
 
         for (final com.intellij.tasks.Task task : tasks) {
             int taskNodeIndex = getNode().findTaskNode(task);
+
             if (taskNodeIndex < 0) {
+                if(task.getState() == null && task.isClosed()){
+                    continue;
+                }
+
                 ctx.addedCount++;
 
                 // node not found, but got place where insert


### PR DESCRIPTION
Quick fix for issue #13 

Generic tasks do not have a state, cannot be filtered, and they are
fetched even if 'closed' flag is set to true. This will skip all closed
tasks on IDE startup (i.e. on task list refresh).